### PR TITLE
wait for threads to terminate before returning.

### DIFF
--- a/src/main/java/loadgenerator/strategies/ConstIncreaseCPULoad.java
+++ b/src/main/java/loadgenerator/strategies/ConstIncreaseCPULoad.java
@@ -117,17 +117,16 @@ public class ConstIncreaseCPULoad implements LoadGenerationStrategyI {
         long currentTime = System.currentTimeMillis();
         for (double load = stepSize; load <= 1.0; load += stepSize) {
             System.err.println("CPU load changing to " + load);
-            CPULoad.createLoad(processorArchInfo.getNumCores(),
-                    processorArchInfo.getNumThreadsPerCore(),
-                    load,
-                    duration,
-                    isAlt,
-                    segments);
-            // Changing load only every <duration>/1000 seconds. If <duration>/1000 seconds has not elapsed, then we wait.
             try {
-                Thread.sleep(duration);
-            } catch (InterruptedException ie) {
-                System.err.println(String.format("%d second wait has been interrupted! Next load change will happen sooner than you think.", (duration / 1000)));
+                CPULoad.createLoad(processorArchInfo.getNumCores(),
+                        processorArchInfo.getNumThreadsPerCore(),
+                        load,
+                        duration,
+                        isAlt,
+                        segments);
+            } catch (InterruptedException e) {
+                System.err.println("interrupted! Next load change will happen sooner than you think.");
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/loadgenerator/strategies/ConstantCPULoad.java
+++ b/src/main/java/loadgenerator/strategies/ConstantCPULoad.java
@@ -98,12 +98,17 @@ public class ConstantCPULoad implements LoadGenerationStrategyI {
     public void execute() {
         System.out.println(String.format("Generating %f %% CPU load for %d seconds",
                 cpuLoad, duration));
-        CPULoad.createLoad(processorArchInfo.getNumCores(),
-                processorArchInfo.getNumThreadsPerCore(),
-                cpuLoad,
-                duration,
-                false,
-                0);
+        try {
+            CPULoad.createLoad(processorArchInfo.getNumCores(),
+                    processorArchInfo.getNumThreadsPerCore(),
+                    cpuLoad,
+                    duration,
+                    false,
+                    0);
+        } catch (InterruptedException e) {
+            System.err.println("threads generating constant cpu load interrupted!");
+            e.printStackTrace();
+        }
         System.out.println("Done generating CPU load!");
     }
 }

--- a/src/main/java/loadgenerator/util/CPULoad.java
+++ b/src/main/java/loadgenerator/util/CPULoad.java
@@ -23,6 +23,9 @@
  */
 package loadgenerator.util;
 
+import java.util.List;
+import java.util.ArrayList;
+
 /**
  * Generates Load on the CPU by keeping it busy for the given load percentage
  * @author Sriram
@@ -44,15 +47,26 @@ public class CPULoad {
      * @param segments Number of alternating segments, for an alternating CPU load, for the specified duration.
      */
     public static void createLoad(int numCore, int numThreadsPerCore, double load,
-                                  long duration, boolean isAlt, int segments) {
+                                  long duration, boolean isAlt, int segments) throws InterruptedException {
+        List<Thread> threads = new ArrayList<>();
         if (isAlt) {
             for (int thread = 0; thread < numCore * numThreadsPerCore; thread++) {
-                new AltBusyThread("Thread" + thread, load, duration, segments).start();
+                threads.add(new AltBusyThread("Thread" + thread, load, duration, segments));
             }
         } else {
             for (int thread = 0; thread < numCore * numThreadsPerCore; thread++) {
-                new BusyThread("Thread" + thread, load, duration).start();
+                threads.add(new BusyThread("Thread" + thread, load, duration));
             }
+        }
+
+        // starting threads.
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // waiting for all threads to complete.
+        for (Thread thread : threads) {
+            thread.join(); // throws InterruptedException.
         }
     }
 


### PR DESCRIPTION
with this commit, CPULoad#createLoad(...) would be a blocking call.
The threads are kept track of and the function waits for them to
terminate before returning.

As we're now waiting for the threads to wait, we don't require explicit
Time.sleep(...) calls.